### PR TITLE
Task 5 - feat: Criação de migration products

### DIFF
--- a/src/database/migrations/20231004020916-create-table-products.js
+++ b/src/database/migrations/20231004020916-create-table-products.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+
+    await queryInterface.createTable('products', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+        unique: true,
+        allowNull: false
+      },
+      user_id: {
+        type: Sequelize.INTEGER,
+        references: { model: "users", key: "id" },
+        allowNull: false
+      },
+      name: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      lab_name: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      image_link: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      dosage: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      unit_price: {
+        type: Sequelize.REAL,
+        allowNull: false
+      },
+      total_stock: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      type_product: {
+        type: Sequelize.ENUM("Controled Medicine", "Uncontroled Medication"),
+        allowNull: false
+      },
+      description: {
+        type: Sequelize.STRING,
+        allowNull: true,
+        default: null
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      deleted_at: {
+        type: Sequelize.DATE,
+        allowNull: true
+      }
+    });
+
+  },
+
+  async down(queryInterface, Sequelize) {
+
+    await queryInterface.dropTable('products');
+
+  }
+};


### PR DESCRIPTION
Foi realizada a criação da migration da tabela products.
Para testar deve-se clonar o repositório e acessar a branch task5-willyan, instalar as dependências e configurar as variáveis de ambiente. Em seguida rodar o comando:
`npx sequelize-cli db:migration`

Após isso a tabela products será criada e um novo campo na tabela SequelizeMeta será criado.
![image](https://github.com/FullStack-Itaguacu/M3P-BackEnd-Squad1/assets/112450732/d14decb7-0a68-43e8-b39c-8591e4b6104c)

Em seguida pode-se rodar o seguinte comando para verificar se a tabela é apagada:
`npx sequelize-cli db:migrate:undo`
Retirando a migration de products da tabela SequelizeMeta.
![image](https://github.com/FullStack-Itaguacu/M3P-BackEnd-Squad1/assets/112450732/4cc8b6e4-b59a-458d-aa4f-c1c9084877a5)
