### PR TITLE
✨️ Foi fixado como Buyer o type_user no cadastro de usuarios por que …

### DIFF
--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -26,10 +26,14 @@ module.exports = {
       await filtroBodySignUp(user, addresses);
       await validaSenha(user.password);
       user.password = await encriptarSenha(user.password);
+      // fixando o tipo de usuário como Buyer para evitar que o usuário se cadastre como Admin
+      user.type_user = "Buyer";
+
 
       const userCreated = await User.create(user);
       const addressesCreated = await Address.bulkCreate(addresses);
       userCreated.setAddresses(addressesCreated);
+      successMessage(res, userCreated, addressesCreated);
 
     } catch (error) {
       errorLauncher(error, res);


### PR DESCRIPTION
# ✨️ Foi fixado como Buyer o type_user no cadastro de usuarios por que permitia que ele se cadastrasse sozinho como admin, tambem voltei addicionar a funçao  successMessage que debe ter se perdido em alguma resoluçao de conflitos