### PR TITLE
Task 41 - fix: Alteração de lógica para atualização de dados dos usuários

### DIFF
--- a/src/controllers/buyers.controller.js
+++ b/src/controllers/buyers.controller.js
@@ -31,43 +31,46 @@ module.exports = {
 
 
 
-     if(full_name && !created_at ){await searchOffsetLimit(
-      start,
-      items_for_page,
-      actual_page,
-      full_name,
-      created_at = 'ASC',
-      res,
-      User
-    );} 
-    if(created_at && !full_name){await searchOffsetLimit(
-      start,
-      items_for_page,
-      actual_page,
-      full_name = '%',
-      created_at ,
-      res,
-      User)
-    }
-    if(!full_name && !created_at){
-    await searchOffsetLimit(
-      start,
-      items_for_page,
-      actual_page,
-      full_name = '%',
-      created_at = 'ASC',
-      res,
-      User)
-    }
-    if(full_name && created_at){
-      await searchOffsetLimit(
-        start,
-        items_for_page,
-        actual_page,
-        full_name ,
-        created_at ,
-        res,
-        User)
+      if (full_name && !created_at) {
+        await searchOffsetLimit(
+          start,
+          items_for_page,
+          actual_page,
+          full_name,
+          created_at = 'ASC',
+          res,
+          User
+        );
+      }
+      if (created_at && !full_name) {
+        await searchOffsetLimit(
+          start,
+          items_for_page,
+          actual_page,
+          full_name = '%',
+          created_at,
+          res,
+          User)
+      }
+      if (!full_name && !created_at) {
+        await searchOffsetLimit(
+          start,
+          items_for_page,
+          actual_page,
+          full_name = '%',
+          created_at = 'ASC',
+          res,
+          User)
+      }
+      if (full_name && created_at) {
+        await searchOffsetLimit(
+          start,
+          items_for_page,
+          actual_page,
+          full_name,
+          created_at,
+          res,
+          User)
       }
 
     } catch (error) {
@@ -144,18 +147,16 @@ module.exports = {
       const { full_name, email, phone, cpf, type_user } = req.body;
       const data = await verifyUserId(user_id);
 
-      const userToUpdate = await User.findByPk(user_id);
-      if (!userToUpdate || userToUpdate.type_user !== "Buyer") {
+      if (!data || data.type_user !== "Buyer") {
         return res.status(404).json({
           status: 404,
           error: "UserNotFound",
-          message: "Usuário não encontrado ou não é um 'Buyer'.",
+          message: "Usuário não foi encontrado ou não é um 'Buyer'.",
           cause: "O usuário a ser atualizado deve ser do tipo 'Buyer'.",
         });
       }
-      const currentUser = await User.findByPk(user_id);
 
-      if (currentUser.type_user === "Admin" && type_user === "Buyer") {
+      if (data.type_user === "Admin" && type_user === "Buyer") {
         return res.status(422).json({
           error: "BadFormatRequest",
           status: 422,
@@ -174,11 +175,11 @@ module.exports = {
           });
         }
       }
-      if (cpf !== undefined) {
+      if (cpf !== undefined && cpf !== data.cpf) {
         await verifyCpfExist(cpf);
       }
 
-      if (email !== undefined) {
+      if (email !== undefined && email !== data.email) {
         await verifyEmailExist(email);
       }
 
@@ -206,7 +207,18 @@ module.exports = {
         data.type_user = type_user;
       }
 
-      await data.save();
+      await User.update({
+        full_name,
+        email,
+        phone,
+        cpf,
+        type_user
+      },
+        {
+          where: {
+            id: user_id
+          }
+        });
 
       return res.status(204).json({
         status: 204,

--- a/src/services/user.services.js
+++ b/src/services/user.services.js
@@ -178,7 +178,7 @@ module.exports = {
       throw new UserNotFound();
     }
 
-    return data;
+    return data.dataValues;
   },
   async verifyCpfExist(cpf) {
     if (await estaNaBD(User, "cpf", cpf)) {


### PR DESCRIPTION
Foi modificado a lógica para aceitar o mesmo email ou cpf na mudança de dados do mesmo usuário. Porém é lançado erro no caso de pertencerem à outra pessoa cadastrada no sistema. Foi modificado a mensagem de erro indicando o método PATCH da rota de alteração de usuário.
Para testar rode o comando:
`git checkout task41_willyan`

Em seguida rode:
`npm run dev`

Para testar, acesse o endpoint sem efetuar a troca de email e cpf envie a requisição:
![image](https://github.com/FullStack-Itaguacu/M3P-BackEnd-Squad1/assets/112450732/40c7b64d-6cfe-4ebd-b46a-3d4229115ae4)

Caso coloque o cpf de **outro** usuário já cadastrado no sistema:
![image](https://github.com/FullStack-Itaguacu/M3P-BackEnd-Squad1/assets/112450732/d85d0e37-5303-4688-a340-4092d711b68a)

Caso coloque o email de **outro** usuário já cadastrado no sistema:
![image](https://github.com/FullStack-Itaguacu/M3P-BackEnd-Squad1/assets/112450732/e07a6324-b5b6-4129-a1f6-03086da2027d)
