### PR TITLE
🆕️ Config: GET /api/buyers/address

### DIFF
--- a/src/models/userAddress.js
+++ b/src/models/userAddress.js
@@ -15,6 +15,10 @@ const UserAddress = connection.define(
       allowNull: false,
       type: DataTypes.INTEGER,
     },
+    users_addresses_id :{
+      field: 'id',
+      type: DataTypes.INTEGER,
+    }
   
   },
   {


### PR DESCRIPTION
Mudo-se configuração do endpoint GET/api/buyers/address para devolver na requirição o user_addresses_id também.
Na models de usser addresses se referencia uma “prop” user_addresses_id com a Id da tabela.
```javascript
 users_addresses_id :{
      field: 'id',
      type: DataTypes.INTEGER,
    }
```

Consulta no endpoint agora devolve usser_addresses_id necessário no frontend de Usuário para o carrinho de compras
![image](https://github.com/FullStack-Itaguacu/M3P-BackEnd-Squad1/assets/124309725/d8bf97a0-b3b0-40e0-9639-6f0cd0c3e9e8)


