### PR TITLE
Task 22.2 - refactor: Refatoração no algoritmo de busca de usuários no banco de dados

### DIFF
--- a/src/controllers/buyers.controller.js
+++ b/src/controllers/buyers.controller.js
@@ -17,61 +17,34 @@ const { verificaNumeroPositivo, verificaSomenteNumeros } = require("../services/
 module.exports = {
   async getBuyersOffsetLimit(req, res) {
     try {
-      var { full_name, created_at } = req.query;
-      var { offset, limit } = req.params;
+      let { full_name, created_at } = req.query;
+      let { offset, limit } = req.params;
 
-      await filtroBodyOffsetLimitSearch(offset, limit, full_name, created_at);
+      await filtroBodyOffsetLimitSearch(offset, limit);
 
       const items_for_page = parseInt(limit);
       const actual_page = parseInt(offset);
       //calculo para saber o inicio da paginação no banco de dados
-      var start = parseInt((actual_page - 1) * items_for_page);
+      let start = parseInt((actual_page - 1) * items_for_page);
       //se o start for menor que 0, será setado em 0 para não quebrar a paginação
       start < 0 ? (start = 0) : (start = start);
 
+      if (!full_name) {
+        full_name = '%'
+      }
 
+      if (!created_at) {
+        created_at = 'ASC'
+      }
 
-      if (full_name && !created_at) {
-        await searchOffsetLimit(
-          start,
-          items_for_page,
-          actual_page,
-          full_name,
-          created_at = 'ASC',
-          res,
-          User
-        );
-      }
-      if (created_at && !full_name) {
-        await searchOffsetLimit(
-          start,
-          items_for_page,
-          actual_page,
-          full_name = '%',
-          created_at,
-          res,
-          User)
-      }
-      if (!full_name && !created_at) {
-        await searchOffsetLimit(
-          start,
-          items_for_page,
-          actual_page,
-          full_name = '%',
-          created_at = 'ASC',
-          res,
-          User)
-      }
-      if (full_name && created_at) {
-        await searchOffsetLimit(
-          start,
-          items_for_page,
-          actual_page,
-          full_name,
-          created_at,
-          res,
-          User)
-      }
+      await searchOffsetLimit(
+        start,
+        items_for_page,
+        actual_page,
+        full_name,
+        created_at,
+        res,
+        User)
 
     } catch (error) {
       errorLauncher(error, res);

--- a/src/services/buyeres.services.js
+++ b/src/services/buyeres.services.js
@@ -8,7 +8,7 @@ const {
   UserNotFound,
 } = require("../services/customs.errors.services.js");
 module.exports = {
-  async filtroBodyOffsetLimitSearch(offset, limit, full_name, created_at) {
+  async filtroBodyOffsetLimitSearch(offset, limit) {
     if (isNaN(offset)) {
       throw new OffsetIsNan();
     }
@@ -108,8 +108,8 @@ module.exports = {
       where: {
         id: user_id,
       },
-      attributes : {
-        exclude : ["password"]
+      attributes: {
+        exclude: ["password"]
       }
     });
 


### PR DESCRIPTION
Alterações:
- A função getBuyersOffsetLimit foi refatorada.
- Foi alterado o tipo das variáveis full_name, created_by, offset e limit de var para let.
- Foi retirado parâmetros e argumentos full_name e created_by da função filtroBodyOffsetLimitSearch pois não estavam sendo usados.
Para testar acesse a branch:
`git checkout refactor22.2_willyan`

Em seguida execute:
`npm run dev`

E acesse o endpoint seguinte, informando o offset e o limit no path params, este endpoint também aceita as query params full_name e created_at:
`http://localhost:3000/api/buyers/admin/0/5`

Em caso de full_name e created_at vazios:
![image](https://github.com/FullStack-Itaguacu/M3P-BackEnd-Squad1/assets/112450732/d9725568-f70c-4adf-8b8e-7af129746639)

Caso passe somente created_at como DESC:
![image](https://github.com/FullStack-Itaguacu/M3P-BackEnd-Squad1/assets/112450732/03117c85-721b-4b85-9802-6bc59322424f)

Caso passe somente o full_name:
![image](https://github.com/FullStack-Itaguacu/M3P-BackEnd-Squad1/assets/112450732/0f435b62-5740-400c-9c95-b35cdbfcfe25)

Com full_name e created_at com valor DESC:
![image](https://github.com/FullStack-Itaguacu/M3P-BackEnd-Squad1/assets/112450732/7b9ccb17-83e5-468e-9d6c-f2fda6da9dd4)
